### PR TITLE
Update: allow 1.8.0_74

### DIFF
--- a/tasks/set-role-variables.yml
+++ b/tasks/set-role-variables.yml
@@ -7,6 +7,13 @@
   set_fact:
     jdk_arch: "{{ 'i586' if ansible_architecture == 'i386' else 'x64'}}"
 
+- name: set internal vars for 1.8.0_74
+  set_fact:
+    jdk_version:      1.8.0_74
+    jdk_tarball_file: jdk-8u74-linux-{{ jdk_arch }}
+    jdk_tarball_url:  http://download.oracle.com/otn-pub/java/jdk/8u74-b02/jdk-8u74-linux-{{ jdk_arch }}
+  when: java_version == 8 and java_subversion == 74
+
 - name: set internal vars for 1.8.0_72
   set_fact:
     jdk_version:      1.8.0_72


### PR DESCRIPTION
Allow the use of Oracle JDK 8u74. Does not change the current default of 8u72.
