### PR TITLE
Mac OS X support and an updated installation directory on Debian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+*.retry

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,16 @@
 sudo: true
+os:
+    - linux
+    - osx
+
 services:
     - docker
 
 before_install:
-    - docker info
-    - docker version
-
-    - echo "==> Prefetching .rpm and .tar.gz to `{{ playbook_dir }}/files`..."
-    - docker build  -f test/Dockerfile-prefetch-rpm      -t java_prefetch_rpm .
-    - docker run    -v $(pwd):/data  java_prefetch_rpm
-    - docker build  -f test/Dockerfile-prefetch-tarball  -t java_prefetch_tarball .
-    - docker run    -v $(pwd):/data  java_prefetch_tarball
-    - sed -i -e 's/^\(java_download_from_oracle:\).*$/\1 false/'  defaults/main.yml
-
-
-    - echo "==> Building test cases..."
-    - docker build  -f test/Dockerfile-ubuntu14.04  -t java_trusty   .
-    - docker build  -f test/Dockerfile-ubuntu12.04  -t java_precise  .
-    - docker build  -f test/Dockerfile-debian8      -t java_jessie   .
-    - docker build  -f test/Dockerfile-debian7      -t java_wheezy   .
-    - docker build  -f test/Dockerfile-centos7      -t java_centos7  .
-    - docker build  -f test/Dockerfile-centos6      -t java_centos6  .
+    - test/travis/before_install.sh
 
 script:
-    - docker run -i java_trusty   2> result-ubuntu14.04
-    - docker run -i java_precise  2> result-ubuntu12.04
-    - docker run -i java_jessie   2> result-debian8
-    - docker run -i java_wheezy   2> result-debian7
-    - docker run -i java_centos7  2> result-centos7
-    - docker run -i java_centos6  2> result-centos6
-
-    - echo "==> Validating the test results..."
-    - sh -c "[ -s result-ubuntu14.04 ]"
-    - sh -c "[ -s result-ubuntu12.04 ]"
-    - sh -c "[ -s result-debian8     ]"
-    - sh -c "[ -s result-debian7     ]"
-    - sh -c "[ -s result-centos7     ]"
-    - sh -c "[ -s result-centos6     ]"
+    - test/travis/script.sh
 
 notifications:
     webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/tasks/fetch.yml
+++ b/tasks/fetch.yml
@@ -7,14 +7,21 @@
     url:     "{{ jdk_tarball_url }}.rpm"
     headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
     dest:    "{{ java_download_path }}/{{ jdk_tarball_file }}.rpm"
-  when: ansible_pkg_mgr == "yum"
+  when: ansible_pkg_mgr == "yum" and ansible_os_family != 'Darwin'
 
 - name: get JDK tarball (as tar.gz file)
   get_url:
     url:     "{{ jdk_tarball_url }}.tar.gz"
     headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
     dest:    "{{ java_download_path }}/{{ jdk_tarball_file }}.tar.gz"
-  when: ansible_pkg_mgr != "yum"
+  when: ansible_pkg_mgr != "yum" and ansible_os_family != 'Darwin'
+
+- name: get JDK package (as Mac OS X .dmg)
+  get_url:
+    url:     "{{ jdk_tarball_url }}.dmg"
+    headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
+    dest:    "{{ java_download_path }}/{{ jdk_tarball_file }}.dmg"
+  when: ansible_os_family == 'Darwin'
 
 - name: get JCE
   get_url:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -34,44 +34,70 @@
 
 - name: delegate to RPM installation process
   include: use-rpm.yml
-  when: ansible_pkg_mgr == "yum"
+  when: ansible_pkg_mgr == "yum" and ansible_os_family != 'Darwin'
 
 - name: delegate to raw tarball installation process
   include: use-tarball.yml
-  when: ansible_pkg_mgr != "yum"
+  when: ansible_pkg_mgr != "yum" and ansible_os_family != 'Darwin'
+
+- name: delegate to Mac OS X dmg installation
+  include: use-dmg.yml
+  when: ansible_os_family == 'Darwin'
 
 - name: delegate to JCE zip installation process
   include: install_jce.yml
   when: java_install_jce
 
 
-- name: link /usr/java/default
-  file: dest=/usr/java/default src="/usr/java/jdk{{ jdk_version }}" state=link
+- name: link "{{ java_install_dir }}/{{ java_default_link_name }}"
+  file:
+    dest: "{{ java_install_dir }}/{{ java_default_link_name }}"
+    src: "{{ java_install_dir }}/jdk{{ jdk_version }}"
+    state: link
+  when: ansible_os_family != "Darwin"
 
 - name: alternatives link for "java"
-  alternatives: name=java link=/usr/bin/java  path=/usr/java/default/bin/java
+  alternatives:
+    name: java
+    link: /usr/bin/java
+    path: "{{ java_install_dir }}/{{ java_default_link_name }}/bin/java"
+  when: ansible_os_family != "Darwin"
 
 - name: alternatives link for "javac"
-  alternatives: name=javac link=/usr/bin/javac  path=/usr/java/default/bin/javac
+  alternatives:
+    name: javac
+    link: /usr/bin/javac
+    path: "{{ java_install_dir }}/{{ java_default_link_name }}/bin/javac"
+  when: ansible_os_family != "Darwin"
 
 - name: alternatives link for "jar"
-  alternatives: name=jar link=/usr/bin/jar  path=/usr/java/default/bin/jar
+  alternatives:
+    name: jar
+    link: /usr/bin/jar
+    path: "{{ java_install_dir }}/{{ java_default_link_name }}/bin/jar"
+  when: ansible_os_family != "Darwin"
+
+# No link creation is necessary on Mac OS X -- the package installer automatically creates
+# symlinks in /usr/bin.
 
 - name: check if "java_sdk" target exists
   stat: path=/usr/lib/jvm/java
   register: filecheck
+  when: ansible_os_family != "Darwin"
 
 - name: alternatives link for "java_sdk"
-  alternatives: name=java_sdk link=/usr/lib/jvm/java  path=/usr/java/default
-  when: filecheck.stat.exists
-
-
+  alternatives:
+    name: java_sdk
+    link: /usr/lib/jvm/java
+    path: "{{ java_install_dir }}/{{ java_default_link_name }}"
+  when: ansible_os_family != "Darwin" and filecheck and filecheck.stat.exists
 
 - name: remove temporary downloaded files, if requested
   file: path={{ item }} state=absent
   with_items:
     - "{{ java_download_path }}/{{ jdk_tarball_file }}.rpm"
     - "{{ java_download_path }}/{{ jdk_tarball_file }}.tar.gz"
+    - "{{ java_download_path }}/{{ jdk_tarball_file }}.dmg"
     - "{{ java_download_path }}/check-tarball-installed.sh"
     - "{{ java_download_path }}/{{ jce_zip_file }}"
     - "{{ java_download_path }}/{{ jce_zip_folder }}"

--- a/tasks/set-role-variables.yml
+++ b/tasks/set-role-variables.yml
@@ -19,56 +19,56 @@
     jdk_version:      1.8.0_74
     jdk_tarball_file: jdk-8u74-linux-{{ jdk_arch }}
     jdk_tarball_url:  http://download.oracle.com/otn-pub/java/jdk/8u74-b02/jdk-8u74-linux-{{ jdk_arch }}
-  when: java_version == 8 and java_subversion == 74
+  when: java_version == 8 and java_subversion == 74 and ansible_os_family != 'Darwin'
 
 - name: set internal vars for 1.8.0_72
   set_fact:
     jdk_version:      1.8.0_72
     jdk_tarball_file: jdk-8u72-linux-{{ jdk_arch }}
     jdk_tarball_url:  http://download.oracle.com/otn-pub/java/jdk/8u72-b15/jdk-8u72-linux-{{ jdk_arch }}
-  when: java_version == 8 and java_subversion == 72
+  when: java_version == 8 and java_subversion == 72 and ansible_os_family != 'Darwin'
 
 - name: set internal vars for 1.8.0_66
   set_fact:
     jdk_version:      1.8.0_66
     jdk_tarball_file: jdk-8u66-linux-{{ jdk_arch }}
     jdk_tarball_url:  http://download.oracle.com/otn-pub/java/jdk/8u66-b17/jdk-8u66-linux-{{ jdk_arch }}
-  when: java_version == 8 and java_subversion == 66
+  when: java_version == 8 and java_subversion == 66 and ansible_os_family != 'Darwin'
 
 - name: set internal vars for 1.8.0_65
   set_fact:
     jdk_version:      1.8.0_65
     jdk_tarball_file: jdk-8u65-linux-{{ jdk_arch }}
     jdk_tarball_url:  http://download.oracle.com/otn-pub/java/jdk/8u65-b17/jdk-8u65-linux-{{ jdk_arch }}
-  when: java_version == 8 and java_subversion == 65
+  when: java_version == 8 and java_subversion == 65 and ansible_os_family != 'Darwin'
 
 - name: set internal vars for 1.8.0_60
   set_fact:
     jdk_version:      1.8.0_60
     jdk_tarball_file: jdk-8u60-linux-{{ jdk_arch }}
     jdk_tarball_url:  http://download.oracle.com/otn-pub/java/jdk/8u60-b27/jdk-8u60-linux-{{ jdk_arch }}
-  when: java_version == 8 and java_subversion == 60
+  when: java_version == 8 and java_subversion == 60 and ansible_os_family != 'Darwin'
 
 - name: set internal vars for 1.8.0_51
   set_fact:
     jdk_version:      1.8.0_51
     jdk_tarball_file: jdk-8u51-linux-{{ jdk_arch }}
     jdk_tarball_url:  http://download.oracle.com/otn-pub/java/jdk/8u51-b16/jdk-8u51-linux-{{ jdk_arch }}
-  when: java_version == 8 and java_subversion == 51
+  when: java_version == 8 and java_subversion == 51 and ansible_os_family != 'Darwin'
 
 - name: set internal vars for 1.8.0_45
   set_fact:
     jdk_version:      1.8.0_45
     jdk_tarball_file: jdk-8u45-linux-{{ jdk_arch }}
     jdk_tarball_url:  http://download.oracle.com/otn-pub/java/jdk/8u45-b14/jdk-8u45-linux-{{ jdk_arch }}
-  when: java_version == 8 and java_subversion == 45
+  when: java_version == 8 and java_subversion == 45 and ansible_os_family != 'Darwin'
 
 - name: set internal vars for 1.8.0_31
   set_fact:
     jdk_version:      1.8.0_31
     jdk_tarball_file: jdk-8u31-linux-{{ jdk_arch }}
     jdk_tarball_url:  http://download.oracle.com/otn-pub/java/jdk/8u31-b13/jdk-8u31-linux-{{ jdk_arch }}
-  when: java_version == 8 and java_subversion == 31
+  when: java_version == 8 and java_subversion == 31 and ansible_os_family != 'Darwin'
 
 - name: set JCE zip to use for 1.8.x JCE
   set_fact:
@@ -89,14 +89,36 @@
     jdk_version:      1.7.0_80
     jdk_tarball_file: jdk-7u80-linux-{{ jdk_arch }}
     jdk_tarball_url:  http://download.oracle.com/otn-pub/java/jdk/7u80-b15/jdk-7u80-linux-{{ jdk_arch }}
-  when: java_version == 7 and java_subversion == 80
+  when: java_version == 7 and java_subversion == 80 and ansible_os_family != 'Darwin'
 
 - name: set internal vars for 1.7.0_75
   set_fact:
     jdk_version:      1.7.0_75
     jdk_tarball_file: jdk-7u75-linux-{{ jdk_arch }}
     jdk_tarball_url:  http://download.oracle.com/otn-pub/java/jdk/7u75-b13/jdk-7u75-linux-{{ jdk_arch }}
-  when: java_version == 7 and java_subversion == 75
+  when: java_version == 7 and java_subversion == 75 and ansible_os_family != 'Darwin'
+
+- name: set internal vars for 1.8.0_73 on Mac OS X
+  set_fact:
+    jdk_version:      "1.{{ java_version }}.0_{{ java_subversion }}"
+    jdk_tarball_file: "jdk-{{ java_version }}u{{ java_subversion }}-macosx-{{ jdk_arch }}"
+    jdk_tarball_url:  http://download.oracle.com/otn-pub/java/jdk/8u73-b02/jdk-8u73-macosx-{{ jdk_arch }}
+  when: java_version == 8 and java_subversion == 73 and ansible_os_family == 'Darwin'
+
+- name: set internal vars for 1.8.0_74 on Mac OS X
+  set_fact:
+    jdk_version:      "1.{{ java_version }}.0_{{ java_subversion }}"
+    jdk_tarball_file: "jdk-{{ java_version }}u{{ java_subversion }}-macosx-{{ jdk_arch }}"
+    jdk_tarball_url:  "http://download.oracle.com/otn-pub/java/jdk/{{ java_version }}u{{ java_subversion }}-b02/jdk-{{ java_version }}u{{ java_subversion }}-macosx-{{ jdk_arch }}"
+  when: java_version == 8 and java_subversion == 74 and ansible_os_family == 'Darwin'
+
+- name: set internal vars for 1.8.0_77 on Mac OS X
+  set_fact:
+    jdk_version:      "1.{{ java_version }}.0_{{ java_subversion }}"
+    jdk_tarball_file: "jdk-{{ java_version }}u{{ java_subversion }}-macosx-{{ jdk_arch }}"
+    jdk_tarball_url:  "http://download.oracle.com/otn-pub/java/jdk/{{ java_version }}u{{ java_subversion }}-b03/jdk-{{ java_version }}u{{ java_subversion }}-macosx-{{ jdk_arch }}"
+  when: java_version == 8 and java_subversion == 77 and ansible_os_family == 'Darwin'
+
 
 - name: set JCE zip file to use for 1.7.x JCE
   set_fact:
@@ -108,3 +130,23 @@
   set_fact:
     jce_zip_url:    http://download.oracle.com/otn-pub/java/jce/7/{{ jce_zip_file }}
   when: java_version == 7 and java_install_jce
+
+
+- name: set java installation directory on Debian platforms
+  set_fact:
+    java_install_dir: /usr/lib/jvm
+    java_default_link_name: default-java
+  when: ansible_os_family == "Debian"
+
+- name: set java installation directory on Mac OS X
+  set_fact:
+    # The Java installation directory on Mac OS X is determined by the package itself.
+    java_install_dir: /no_such_directory
+    java_default_link_name: default
+  when: ansible_os_family == "Darwin"
+
+- name: set java installation directory on non-Debian platforms platforms
+  set_fact:
+    java_install_dir: /usr/java
+    java_default_link_name: default
+  when: ansible_os_family != "Debian" and ansible_os_family != "Darwin"

--- a/tasks/use-dmg.yml
+++ b/tasks/use-dmg.yml
@@ -1,0 +1,20 @@
+---
+# file: use-tarball.yml
+# install Oracle JDK 1.x on Mac OS X
+#
+# See: #      https://docs.oracle.com/javase/8/docs/technotes/guides/install/mac_jdk.html
+#
+
+- name: mount the downloaded dmg
+  shell: hdiutil attach "{{ java_download_path }}/{{ jdk_tarball_file }}.dmg"
+
+- name: install the pkg file from the dmg
+  become: yes
+  become_method: sudo
+  shell: >
+    installer
+    -pkg "/Volumes/JDK {{ java_version }} Update {{ java_subversion }}/JDK {{ java_version }} Update {{ java_subversion }}.pkg"
+    -target /
+
+- name: unmount the downloaded dmg
+  shell: hdiutil detach "/Volumes/JDK {{ java_version }} Update {{ java_subversion }}"

--- a/tasks/use-tarball.yml
+++ b/tasks/use-tarball.yml
@@ -2,12 +2,12 @@
 # file: use-tarball.yml
 # install Oracle JDK 1.x on distributions other than the CentOS/RHEL family
 #
-# See: http://docs.oracle.com/javase/8/docs/technotes/guides/install/linux_jdk.html
+# See: https://docs.oracle.com/javase/8/docs/technotes/guides/install/linux_jdk.html
 #
 
 - name: mkdir for Java
   file:
-    path: "/usr/java/jdk{{ jdk_version }}"
+    path: "{{ java_install_dir }}/jdk{{ jdk_version }}"
     state: directory
     owner: root
     group: root
@@ -16,7 +16,7 @@
 - name: install JDK via tarball file
   unarchive:
     src: "{{ java_download_path }}/{{ jdk_tarball_file }}.tar.gz"
-    dest: "/usr/java"
+    dest: "{{ java_install_dir }}"
     owner: root
     group: root
     mode: "go-w"

--- a/test.yml
+++ b/test.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ test_hosts|default('all') }}"
   become: yes
   become_method: sudo
   tasks:

--- a/test/travis/before_install.sh
+++ b/test/travis/before_install.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -uo pipefail
+
+case "$TRAVIS_OS_NAME" in
+  linux)
+    docker info
+    docker version
+
+    echo "==> Prefetching .rpm and .tar.gz to '$PWD/files'..."
+    docker build  -f test/Dockerfile-prefetch-rpm      -t java_prefetch_rpm .
+    docker run    -v $(pwd):/data  java_prefetch_rpm
+    docker build  -f test/Dockerfile-prefetch-tarball  -t java_prefetch_tarball .
+    docker run    -v $(pwd):/data  java_prefetch_tarball
+    sed -i -e 's/^\(java_download_from_oracle:\).*$/\1 false/'  defaults/main.yml
+
+    echo "==> Building test cases..."
+    docker build  -f test/Dockerfile-ubuntu14.04  -t java_trusty   .
+    docker build  -f test/Dockerfile-ubuntu12.04  -t java_precise  .
+    docker build  -f test/Dockerfile-debian8      -t java_jessie   .
+    docker build  -f test/Dockerfile-debian7      -t java_wheezy   .
+    docker build  -f test/Dockerfile-centos7      -t java_centos7  .
+    docker build  -f test/Dockerfile-centos6      -t java_centos6  .
+  ;;
+  osx)
+    echo "==> Installing Ansible using pip on Mac OS X"
+    sudo pip install ansible
+  ;;
+  *)
+    echo "Unknown value of TRAVIS_OS_NAME: '$TRAVIS_OS_NAME'" >&2
+    exit 1
+esac

--- a/test/travis/script.sh
+++ b/test/travis/script.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -uo pipefail
+
+case "$TRAVIS_OS_NAME" in
+  linux)
+    docker run -i java_trusty   2> result-ubuntu14.04
+    docker run -i java_precise  2> result-ubuntu12.04
+    docker run -i java_jessie   2> result-debian8
+    docker run -i java_wheezy   2> result-debian7
+    docker run -i java_centos7  2> result-centos7
+    docker run -i java_centos6  2> result-centos6
+
+    echo "==> Validating the test results..."
+    sh -c "[ -s result-ubuntu14.04 ]"
+    sh -c "[ -s result-ubuntu12.04 ]"
+    sh -c "[ -s result-debian8     ]"
+    sh -c "[ -s result-debian7     ]"
+    sh -c "[ -s result-centos7     ]"
+    sh -c "[ -s result-centos6     ]"
+  ;;
+  osx)
+    echo "==> Running tests using ansible-playbook on Mac OS X"
+    ansible-playbook test.yml --extra-vars test_hosts=localhost
+  ;;
+  *)
+    echo "Unknown value of TRAVIS_OS_NAME: '$TRAVIS_OS_NAME'" >&2
+    exit 1
+esac


### PR DESCRIPTION
- Adding support for `.dmg`-based installation on Mac OS X (no clicking required!)
- On Debian (or at least on Ubuntu) the convention seems to be that Java is installed into `/usr/lib/jvm/jdk<version>`, and the default version is pointed to by the symlink `/usr/lib/jvm/default-java`
