### PR TITLE
Set JCE role vars unconditionally to avoid errors/deprecation warnings

### DIFF
--- a/tasks/set-role-variables.yml
+++ b/tasks/set-role-variables.yml
@@ -74,12 +74,12 @@
   set_fact:
     jce_zip_file: jce_policy-8.zip
     jce_zip_folder: UnlimitedJCEPolicyJDK8
-  when: java_version == 8 and java_install_jce
+  when: java_version == 8
 
 - name: set internal vars for 1.8.x JCE
   set_fact:
     jce_zip_url:    http://download.oracle.com/otn-pub/java/jce/8/{{ jce_zip_file }}
-  when: java_version == 8 and java_install_jce
+  when: java_version == 8
 
 
 
@@ -102,9 +102,9 @@
   set_fact:
     jce_zip_file: UnlimitedJCEPolicyJDK7.zip
     jce_zip_folder: UnlimitedJCEPolicy
-  when: java_version == 7 and java_install_jce
+  when: java_version == 7
 
 - name: set internal vars for 1.7.x JCE
   set_fact:
     jce_zip_url:    http://download.oracle.com/otn-pub/java/jce/7/{{ jce_zip_file }}
-  when: java_version == 7 and java_install_jce
+  when: java_version == 7


### PR DESCRIPTION
Updated to 2.3.0 today and was greeted by this:

<img width="649" alt="screen shot 2016-04-08 at 1 05 22 pm" src="https://cloud.githubusercontent.com/assets/227608/14400308/0daa666a-fdc4-11e5-80de-d80dc8a0ab81.png">

In order for the remove temp files step to not produce this error, even with JCE installation disabled, the vars backing JCE installation need to be set unconditionally. You could also use default()s in the temp file removal step, but this seems like a better solution to me. OTOH, more than happy to change it if that's what's desired.
