### PR TITLE
Add support for generic Java releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ java_install_jce: false
 
 For other configurable internals, read `tasks/set-role-variables.yml` file; for example, supported `java_version`/`java_subversion` combinations.
 
+If you want to install a Java release which is not supported out-of-the-box, you have to specify the corresponding Java build number in the variable `java_build` in addition to `java_version` and `java_subversion`, e.g.
+```yaml
+---
+- hosts: all
+
+  roles:
+    - williamyeh.oracle-java
+
+  vars:
+    java_version: 8
+    java_subversion: 91
+    java_build: 14
+```
+
 
 ### Customized variables, if absolutely necessary
 

--- a/tasks/set-role-variables.yml
+++ b/tasks/set-role-variables.yml
@@ -92,6 +92,10 @@
     jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b13"
   when: java_version == 7 and java_subversion == 75
 
+- name: set internal vars for generic Java version
+  set_fact:
+    jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b{{ java_build }}"
+  when: jdk_version_detail is not defined and java_build is defined
 
 
 - name: compose filename, if necessary


### PR DESCRIPTION
This rule only supports a fixed set of Java releases. To allow the installation of other Java releases the corresponding Java build number is needed (in addition to the version and subversion).
