### PR TITLE
Always regenerate variables for jdk name and url

### DIFF
--- a/tasks/set-role-variables.yml
+++ b/tasks/set-role-variables.yml
@@ -105,6 +105,7 @@
 - name: set internal vars for generic Java version
   set_fact:
     jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b{{ java_build }}"
+  when: jdk_version_detail is not defined and java_build is defined
 
 
 - name: compose filename, if necessary

--- a/tasks/set-role-variables.yml
+++ b/tasks/set-role-variables.yml
@@ -105,18 +105,15 @@
 - name: set internal vars for generic Java version
   set_fact:
     jdk_version_detail: "{{ java_version }}u{{ java_subversion }}-b{{ java_build }}"
-  when: jdk_version_detail is not defined and java_build is defined
 
 
 - name: compose filename, if necessary
   set_fact:
     jdk_tarball_file: "jdk-{{ java_version }}u{{ java_subversion }}-{{ jdk_os }}-{{ jdk_arch }}"
-  when: jdk_tarball_file is not defined
 
 - name: compose url for downloading file, if necessary
   set_fact:
     jdk_tarball_url:  "http://download.oracle.com/otn-pub/java/jdk/{{ jdk_version_detail }}/{{ jdk_tarball_file }}"
-  when: jdk_version_detail is defined
 
 
 #


### PR DESCRIPTION
This allows us to use this role to install multiple versions of java.

I use this role to provision CI systems that require multiple versions of Java. Attempting to install to different versions of Java resulted in urls that don't exist like:

```
http://download.oracle.com/otn-pub/java/jdk/8u51-b16/jdk-7u80-linux-x64.tar.gz
```

Which obviously gets some versions mixed up.

There might be a better way to solve this, but this fixes the problem for myself.
