### PR TITLE
Fix hardcoded java dir which fails on Ubuntu

### DIFF
--- a/tasks/install_jce.yml
+++ b/tasks/install_jce.yml
@@ -13,12 +13,12 @@
 - name: install local_policy.jar
   copy:
     src: "{{ java_download_path }}/{{ jce_zip_folder }}/local_policy.jar"
-    dest: "/usr/java/jdk{{ jdk_version }}/jre/lib/security/local_policy.jar"
+    dest: "{{java_install_dir}}/jdk{{ jdk_version }}/jre/lib/security/local_policy.jar"
     remote_src: True
 
 - name: install US_export_policy.jar
   copy:
     src: "{{ java_download_path }}/{{ jce_zip_folder }}/US_export_policy.jar"
-    dest: "/usr/java/jdk{{ jdk_version }}/jre/lib/security/US_export_policy.jar"
+    dest: "{{ java_install_dir}}/jdk{{ jdk_version }}/jre/lib/security/US_export_policy.jar"
     remote_src: True
 


### PR DESCRIPTION
JCE installation fails on Ubuntu since java installation dir is hardcoded.
