### PR TITLE
fix when condition for rpm and tar.gz download

### DIFF
--- a/tasks/fetch.yml
+++ b/tasks/fetch.yml
@@ -15,7 +15,7 @@
     url:     "{{ jdk_tarball_url }}.tar.gz"
     headers: 'Cookie:oraclelicense=accept-securebackup-cookie'
     dest:    "{{ java_download_path }}/{{ jdk_tarball_file }}.tar.gz"
-  when: ansible_pkg_mgr != "yum" or ansible_pkg_mgr != "zypper" and ansible_os_family != 'Darwin'
+  when: ansible_pkg_mgr != "yum" and ansible_pkg_mgr != "zypper" and ansible_os_family != 'Darwin'
 
 - name: get JDK package (as Mac OS X .dmg)
   get_url:


### PR DESCRIPTION
When running jdk installation in CentOS, jdk is downloaded twice, first the rpm and second the tar.gz 

I fix the problem in file task/fetch.yml, for changing the condition from or to and