### PR TITLE
fix permissions on JAVA_HOME script

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -47,7 +47,7 @@
       template:
         src:  ../templates/java_home.sh.j2
         dest: /etc/profile.d/java_home.sh
-        mode: "a+x"
+        mode: 0755
 
   when: java_set_javahome
 


### PR DESCRIPTION
The file was not made readable by default, at least in my testing on RHEL 7.